### PR TITLE
Add missing languages; remove duplicates

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,6 +44,8 @@
       <button class="btn-primary" type="submit">search</button><br />
 
       <table border=0>
+        <tr style="height: 10px"></tr>
+
         <tr>
           <td class="tdLabel"><label>Availability:</label></td>
           <td class="tdSelect">
@@ -82,33 +84,58 @@
                 Italian (it), Turkey and Turkish (tr), etc.
 
                 The United Kingdon ccTLD is `uk` but the 2-letter language code
-                `uk` is for the Ukranian language, while Ukrain's ccTLD is `ua`.
+                `uk` is for the Ukranian language, while Ukraine's ccTLD is `ua`.
               -->
-            <select ng-model="lang" class="search" style="width: 8em">
-              <option value="zh">Chinese</option>
+            <select ng-model="lang" class="search" style="width: 11em">
+              <option value="">Any language</option>
+              <option value="af">Afrikaans</option>
+              <option value="ar">Arabic</option>
+              <option value="hy">Armenian</option>
+              <option value="be">Belarusian</option>
+              <option value="bg">Bulgarian</option>
+              <option value="ca">Catalan</option>
+              <option value="zh-CN">Chinese (Simplified)</option>
+              <option value="zh-TW">Chinese (Traditional)</option>
+              <option value="hr">Croatian</option>
               <option value="cs">Czech</option>
               <option value="da">Danish</option>
-              <option value="en" selected>English</option>
+              <option value="nl">Dutch</option>
+              <option value="en">English</option>
+              <option value="eo">Esperanto</option>
               <option value="et">Estonian</option>
+              <option value="tl">Filipino</option>
               <option value="fi">Finnish</option>
               <option value="fr">French</option>
               <option value="de">German</option>
               <option value="el">Greek</option>
-              <option value="he">Hebrew</option>
+              <option value="iw">Hebrew</option>
+              <option value="hi">Hindi</option>
+              <option value="hu">Hungarian</option>
+              <option value="is">Icelandic</option>
+              <option value="id">Indonesian</option>
               <option value="it">Italian</option>
-              <option value="la">Latin</option>
-              <option value="lv">Latvian</option>
               <option value="ja">Japanese</option>
               <option value="ko">Korean</option>
+              <option value="la">Latin</option>
+              <option value="lv">Latvian</option>
+              <option value="lt">Lithuanian</option>
               <option value="no">Norwegian</option>
+              <option value="fa">Persian</option>
+              <option value="pl">Polish</option>
               <option value="pt">Portuguese</option>
+              <option value="ro">Romanian</option>
               <option value="ru">Russian</option>
+              <option value="sr">Serbian</option>
+              <option value="sk">Slovak</option>
+              <option value="sl">Slovenian</option>
+              <option value="es">Spanish</option>
+              <option value="sw">Swahili</option>
               <option value="sv">Swedish</option>
-              <option value="tr">Turkish</option>
               <option value="th">Thai</option>
               <option value="tr">Turkish</option>
               <option value="uk">Ukrainian</option>
               <option value="uz">Uzbek</option>
+              <option value="vi">Vietnamese</option>
               <option value="yi">Yiddish</option>
             </select>
           </td>


### PR DESCRIPTION
Also added spacer after input search box and before options and extended the language selector length given that newly-added languages have long names.