### PR TITLE
Show API status, code, and error message to user

### DIFF
--- a/books.js
+++ b/books.js
@@ -14,10 +14,20 @@
 
 angular.module('Librarian', ['ui.bootstrap']);
 
+function clearApiResponse() {
+  return {
+    hasError: false,
+    code: 200,
+    status: 'OK',
+    message: '',
+  };
+}
+
 function SearchCtrl($scope, $http, $templateCache, $timeout) {
   $scope.query = '';
   $scope.data = {items: []};
-  $scope.status = null;
+  $scope.apiResponse = clearApiResponse();
+  $scope.numErrors = 0;
 
   $scope.filter = 'full';
   $scope.download = '';
@@ -90,6 +100,8 @@ function SearchCtrl($scope, $http, $templateCache, $timeout) {
    * https://developers.google.com/books/docs/v1/using
    */
   $scope.search = function() {
+    $scope.apiResponse = clearApiResponse();
+
     const urlBase = 'https://www.googleapis.com/books/v1/volumes?';
     const urlParamsRaw = {
       callback: 'JSON_CALLBACK',
@@ -108,13 +120,25 @@ function SearchCtrl($scope, $http, $templateCache, $timeout) {
       cache: $templateCache,
     })
       .success(function(data, status) {
-        $scope.data = data;
-        $scope.status = status;
         console.debug('Returned data from Books API:', data);
+        // Note that if there's an `error` submessage in the returned `data`,
+        // that status trumps the one separately sent with the API response.
+        console.debug('Returned status from Books API:', status);
+        $scope.data = data;
+        if ('error' in data) {
+          const error = data.error;
+          $scope.apiResponse.code = error.code;
+          $scope.apiResponse.hasError = (error.code != 200);
+          $scope.apiResponse.status = error.status;
+          $scope.apiResponse.message = error.message;
+
+          $scope.numErrors++;
+        }
       })
       .error(function(data, status) {
+        console.debug('Error: returned data from Books API:', data);
+        console.debug('Error: returned status from Books API:', status);
         $scope.data = data || "Request failed";
-        $scope.status = status;
       });
   };
 }

--- a/index.html
+++ b/index.html
@@ -144,6 +144,15 @@
         </tr>
 
       </table>
+
+      <div ng-if="apiResponse.hasError" style="margin-top: 20px">
+        <div>
+          <b>Error {{apiResponse.code}} {{apiResponse.status}}:</b> {{apiResponse.message}}
+        </div>
+        <div style="margin-top: 10px">
+          This is error #{{numErrors}} in this session.
+        </div>
+      </div>
     </div>
   </form>
 


### PR DESCRIPTION
Save and display the error code, status, and full error message in the UI upon errors; these were previously only visible in the Dev Console.

Because the API calls are very fast when they fail, it looks like nothing actually happens when resubmitting the search query. Thus, we add a running count of errors so that the error message updates upon resubmitting the search query and it will show the user that the request is being submitted, but is similarly failing and incrementing the error count.

Combined storage of API response metadata into a separate object, removing top-level `$scope.status` field, which was unused anyway.