### PR TITLE
Add support for bringing Google Books API keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,26 @@ or download it for your ebook reader.
 See the [live demo](https://mbrukman.github.io/librarian/), or clone this
 repository and then open `index.html` in your browser to try it out.
 
+## Google Books API key
+
+The unauthenticated Google Books API has strict quota limits which are
+frequently exhausted because the whole world shares the same limited quota.
+
+If you keep seeing errors that the API quota is exhausted, you can bring your
+own Google Books API key (which is free):
+
+1. Open your Google Cloud Platform project in the [Google Cloud
+	 Console](https://console.cloud.google.com) or create a new one
+2. Open the [Google Books API in the API
+	 Marketplace](https://console.cloud.google.com/marketplace/product/google/books.googleapis.com)
+3. Enable the Google Books API in your project
+3. Open the [Google Books API credentials page](https://console.cloud.google.com/apis/api/books.googleapis.com/credentials)
+4. Create a new API key, limited to Google Books API. You can limit it to "Web
+	 sites" since that's where we are using it.
+5. Paste that API key into the form by expanding the "API key" option. The API
+	 key is only sent to Google Books servers, and is not stored or recorded
+	 anywhere else; this is a purely client-side web app with no server component.
+
 ## Contributing
 
 See [`CONTRIBUTING.md`](CONTRIBUTING.md) for more details.

--- a/books.js
+++ b/books.js
@@ -32,6 +32,8 @@ function SearchCtrl($scope, $http, $templateCache, $timeout) {
   $scope.filter = 'full';
   $scope.download = '';
   $scope.lang = 'en';
+  $scope.apiKey = '';
+  $scope.showApiKey = false;
 
   /**
    * @return {boolean}
@@ -113,6 +115,9 @@ function SearchCtrl($scope, $http, $templateCache, $timeout) {
       printType: 'books',
       q: $scope.query,
     };
+    if ($scope.apiKey && $scope.apiKey.trim()) {
+      urlParamsRaw.key = $scope.apiKey.trim();
+    }
     const urlFull = urlBase + combineUrlParamsNonEmpty(urlParamsRaw);
     $http({
       method: 'JSONP',

--- a/index.html
+++ b/index.html
@@ -143,6 +143,19 @@
           </td>
         </tr>
 
+        <tr>
+          <td class="tdLabel">
+            <label>
+              <a href="" ng-click="showApiKey = !showApiKey" style="text-decoration: none; cursor: pointer; color: black;">
+                {{showApiKey ? '▼ API key:' : '▶ API key:'}}
+              </a>
+            </label>
+          </td>
+          <td class="tdSelect">
+            <input ng-show="showApiKey" ng-model="apiKey" type="text" placeholder="Enter API key" style="width: 11em" />
+          </td>
+        </tr>
+
       </table>
 
       <div ng-if="apiResponse.hasError" style="margin-top: 20px">
@@ -151,6 +164,11 @@
         </div>
         <div style="margin-top: 10px">
           This is error #{{numErrors}} in this session.
+        </div>
+        <div ng-if="!apiKey && numErrors >= 2" style="margin-top: 10px;">
+          If you continue to experience errors, <a
+            href="https://github.com/mbrukman/librarian/tree/main/README.md#google-books-api-key">create
+            a Google Books API key</a> and input it into the box above.
         </div>
       </div>
     </div>


### PR DESCRIPTION
Using the API without a key means we're using the public, unauthenticated search flow which has a limited quota and is very often not available. This can be addressed by creating a free Google Books API key which gives a free quota of 1000 req/day.

It is collapsable so one can add it and then hide it in the UI (e.g., if they want to create a screenshot or share their screen with others), and it is suggested if the user encounters 2+ errors from the unauthenticated API.